### PR TITLE
feat: 연구보고서 섹션 구현

### DIFF
--- a/src/components/Card/InsightCard/InsightCardList.jsx
+++ b/src/components/Card/InsightCard/InsightCardList.jsx
@@ -14,13 +14,13 @@ export default function InsightCardList() {
     const swiperRef = useRef(null);
 
     return (
-        <article className="w-full">
+        <article className="w-full flex flex-col justify-between h-full">
             <h3 className="sr-only">인사이트 / 브리프 카드 목록</h3>
             <SectionTitle 
                 title="인사이트 / 브리프"
                 showArrow
             />
-            <div className="swiper-container-wrapper w-full relative">
+            <div className="swiper-container-wrapper w-full relative h-full">
                 <Swiper
                     onSwiper={(swiper) => {
                         swiperRef.current = swiper;
@@ -87,7 +87,7 @@ export default function InsightCardList() {
             </div>
             
             {/* 스크롤바 */}
-            <div className="insight-swiper-scrollbar mt-6"></div>
+            <div className="insight-swiper-scrollbar mt-[36px]"></div>
         </article>
     );
 }

--- a/src/components/Card/ReportCard/ReportCard.jsx
+++ b/src/components/Card/ReportCard/ReportCard.jsx
@@ -1,0 +1,37 @@
+import { reportData } from "../../../data/reportData";
+
+export default function ReportCard({ data }) {
+    const cardData = data || reportData[0];
+
+    return (
+        <article className="relative w-auto flex-shrink-0">
+            <a 
+                href={cardData.href} 
+                className="block relative w-full cursor-pointer group"
+                role="link"
+                tabIndex="0"
+                aria-label={`${cardData.title} - ${cardData.date}`}
+            >
+                <div className="flex flex-col w-full transition-shadow">
+                    {/* 이미지 영역 */}
+                    <div className="relative w-full aspect-[2/3] group-hover:shadow-xl transition">
+                        <img
+                            src={cardData.image}
+                            alt={cardData.title}
+                            className="w-full h-full object-cover"
+                        />
+                    </div>
+                    
+                    {/* 콘텐츠 영역 */}
+                    <div className="group flex flex-col items-start mt-5 tablet:mt-[18px]">
+                        {/* 날짜 */}
+                        <small className="text-(--color-gray-200) font-medium text-xs tablet:text-sm">
+                            {cardData.date}
+                        </small>
+                    </div>
+                </div>
+            </a>
+        </article>
+    );
+}
+

--- a/src/components/Card/ReportCard/ReportCard.jsx
+++ b/src/components/Card/ReportCard/ReportCard.jsx
@@ -24,6 +24,11 @@ export default function ReportCard({ data }) {
                     
                     {/* 콘텐츠 영역 */}
                     <div className="group flex flex-col items-start mt-5 tablet:mt-[18px]">
+                        {/* 제목 - 스크린 리더 전용 */}
+                        <h4 className="sr-only">
+                            {cardData.title}
+                        </h4>
+                        
                         {/* 날짜 */}
                         <small className="text-(--color-gray-200) font-medium text-xs tablet:text-sm">
                             {cardData.date}

--- a/src/components/Card/ReportCard/ReportCardList.jsx
+++ b/src/components/Card/ReportCard/ReportCardList.jsx
@@ -1,0 +1,94 @@
+import { useRef } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination, Scrollbar } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import 'swiper/css/scrollbar';
+import ReportCard from './ReportCard';
+import { reportData } from '../../../data/reportData';
+import SvgIcon from '../../SvgIcon/SvgIcon';
+import SectionTitle from '../../SectionTitle/SectionTitle';
+
+export default function ReportCardList() {
+    const swiperRef = useRef(null);
+
+    return (
+        <article className="w-full max-w-[1290px] mx-auto pl-[20px] py-[56px] tablet:py-[80px] tablet:px-[15px]">
+            <h3 className="sr-only">연구보고서 카드 목록</h3>
+            <SectionTitle 
+                title="연구보고서"
+                showArrow
+            />
+            <div className="swiper-container-wrapper w-full relative">
+                <Swiper
+                    onSwiper={(swiper) => {
+                        swiperRef.current = swiper;
+                    }}
+                    style={{ width: '100%' }}
+                    modules={[Navigation, Pagination, Scrollbar]}
+                    spaceBetween={16}
+                    slidesPerView={1.5}
+                    breakpoints={{
+                        480: {
+                            slidesPerView: 3.2,
+                        },
+                        769: {
+                            slidesPerView: 4.5,
+                        }
+                    }}
+                    speed={400}
+                    freeMode={true}
+                    watchSlidesProgress={true}
+                    navigation={{
+                        prevEl: '.report-swiper-button-prev',
+                        nextEl: '.report-swiper-button-next',
+                    }}
+                    scrollbar={{
+                        el: '.report-swiper-scrollbar',
+                        draggable: true,
+                    }}
+                    className="report-swiper"
+                    role="list"
+                    aria-label="연구보고서 카드 목록"
+                >
+                    {reportData.map((item) => (
+                        <SwiperSlide key={item.id} role="listitem">
+                            <ReportCard data={item} />
+                        </SwiperSlide>
+                    ))}
+                </Swiper>
+                
+                {/* 네비게이션 버튼 - tablet부터 표시 */}
+                <button
+                    type="button"
+                    className="report-swiper-button-prev hidden tablet:flex absolute -left-5 top-1/2 -translate-y-1/2 z-10 p-5 items-center justify-center cursor-pointer text-gray-500 bg-white rounded-full shadow-md hover:bg-gray-50 transition-colors"
+                    aria-label="이전 슬라이드"
+                >
+                    <SvgIcon 
+                        iconName="icon_arrow_left" 
+                        width={15} 
+                        height={14}
+                        className="text-current"
+                    />
+                </button>
+                <button
+                    type="button"
+                    className="report-swiper-button-next hidden tablet:flex absolute -right-5 top-1/2 -translate-y-1/2 z-10 p-5 items-center justify-center cursor-pointer text-gray-500 bg-white rounded-full shadow-md hover:bg-gray-50 transition-colors"
+                    aria-label="다음 슬라이드"
+                >
+                    <SvgIcon 
+                        iconName="icon_arrow_right" 
+                        width={15} 
+                        height={14}
+                        className="text-current"
+                    />
+                </button>
+            </div>
+            
+            {/* 스크롤바 */}
+            <div className="report-swiper-scrollbar mt-[36px] tablet:mt-[50px]"></div>
+        </article>
+    );
+}
+

--- a/src/components/Card/TrendReportCard/TrendReportCardList.jsx
+++ b/src/components/Card/TrendReportCard/TrendReportCardList.jsx
@@ -29,13 +29,16 @@ export default function TrendReportCardList() {
                     style={{ width: '100%' }}
                     modules={[Navigation, Pagination, Scrollbar]}
                     spaceBetween={16}
-                    slidesPerView={3.5}
+                    slidesPerView={1.5}
                     scrollbar={{
                         el: '.trend-swiper-scrollbar',
                         draggable: true,
                         hide: false,
                     }}
                     breakpoints={{
+                        480: {
+                            slidesPerView: 3.2,
+                        },
                         769: {
                             slidesPerView: 1,
                             freeMode: false,
@@ -99,7 +102,7 @@ export default function TrendReportCardList() {
             <div className="trend-swiper-scrollbar tablet:hidden mt-6"></div>
             
             {/* 페이지네이션 (태블릿 이상) */}
-            <div className="trend-swiper-pagination swiper-pagination-custom hidden tablet:flex items-center justify-center gap-2 mt-6"></div>
+            <div className="trend-swiper-pagination swiper-pagination-custom hidden tablet:flex items-center justify-center gap-2 mt-[30px]"></div>
         </article>
     );
 }

--- a/src/components/InsightTrendReportContent/InsightTrendReportContent.jsx
+++ b/src/components/InsightTrendReportContent/InsightTrendReportContent.jsx
@@ -3,10 +3,10 @@ import TrendReportCardList from "../Card/TrendReportCard/TrendReportCardList";
 
 export default function InsightTrendReportContent() {
     return (
-        <section className="w-full max-w-[1290px] mx-auto pl-[20px] tablet:px-[15px] mb-[60px] tablet:mb-[80px]">
+        <section className="w-full max-w-[1290px] mx-auto pl-[20px] tablet:px-[15px] mb-[56px] tablet:mb-[80px]">
             <h2 className="sr-only">인사이트 및 동향보고서</h2>
 
-            <div className="flex flex-col tablet:flex-row gap-[40px] tablet:gap-[60px]">
+            <div className="flex flex-col tablet:flex-row gap-[56px] tablet:gap-[80px]">
                 <div className="tablet:flex-[3] min-w-0">
                     <InsightCardList />
                 </div>

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -3,6 +3,7 @@ import Header from "../Header/Header";
 import Footer from "../Footer/Footer";
 import MainContent from "../MainContent/MainContent";
 import InsightTrendReportContent from '../InsightTrendReportContent/InsightTrendReportContent';
+import ReportContent from '../ReportContent/ReportContent';
 
 export default function Layout() {
     return (
@@ -11,6 +12,7 @@ export default function Layout() {
             <main>
                 <MainContent />
                 <InsightTrendReportContent />
+                <ReportContent />
             </main>
             <Footer />
         </>

--- a/src/components/ReportContent/ReportContent.jsx
+++ b/src/components/ReportContent/ReportContent.jsx
@@ -1,0 +1,11 @@
+import ReportCardList from "../Card/ReportCard/ReportCardList";
+
+export default function ReportContent() {
+    return (
+        <section className="w-full bg-(--color-bg-yellow-light)">
+            <h2 className="sr-only">연구보고서</h2>
+            <ReportCardList />
+        </section>
+    );
+}
+

--- a/src/data/reportData.js
+++ b/src/data/reportData.js
@@ -15,7 +15,7 @@ export const reportData = [
     },
     {
         id: "report2",
-        title: "특히 데이터를 활용한 귀갑산업 기술 트렌드 분석",
+        title: "특허 데이터를 활용한 관광산업 기술 트렌드 분석",
         date: "2025.01.09",
         image: img2,
         href: "/",
@@ -29,14 +29,14 @@ export const reportData = [
     },
     {
         id: "report4",
-        title: "속학대의 침투와 규제 가산낚",
+        title: "숙박형태의 변화와 규제 개선방안",
         date: "2024.02.29",
         image: img4,
         href: "/",
     },
     {
         id: "report5",
-        title: "김치와",
+        title: "플랫폼 경제와 관광산업",
         date: "2024.01.30",
         image: img5,
         href: "/",

--- a/src/data/reportData.js
+++ b/src/data/reportData.js
@@ -1,0 +1,45 @@
+// ReportCard 더미데이터
+import img1 from "../asset/report/img1.jpg";
+import img2 from "../asset/report/img2.png";
+import img3 from "../asset/report/img3.png";
+import img4 from "../asset/report/img4.png";
+import img5 from "../asset/report/img5.png";
+
+export const reportData = [
+    {
+        id: "report1",
+        title: "지역관광의 경제효과와 활성화 방안",
+        date: "2025.02.07",
+        image: img1,
+        href: "/",
+    },
+    {
+        id: "report2",
+        title: "특히 데이터를 활용한 귀갑산업 기술 트렌드 분석",
+        date: "2025.01.09",
+        image: img2,
+        href: "/",
+    },
+    {
+        id: "report3",
+        title: "호텔 객실 가격 결정을 위한 Revenue Management 연구",
+        date: "2024.04.11",
+        image: img3,
+        href: "/",
+    },
+    {
+        id: "report4",
+        title: "속학대의 침투와 규제 가산낚",
+        date: "2024.02.29",
+        image: img4,
+        href: "/",
+    },
+    {
+        id: "report5",
+        title: "김치와",
+        date: "2024.01.30",
+        image: img5,
+        href: "/",
+    },
+];
+

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -138,7 +138,7 @@
     --color-bg-darkest: #141415;
     --color-bg-orange-light: #FFDFD7;
     --color-bg-pink-light: #FFF4F6;
-    --color-bg-yellow-light: #FFF7EA;
+    --color-bg-yellow-light: #F5EBE1;
     
     /* Text Colors */
     --color-text-primary: #1B1716;
@@ -230,13 +230,13 @@ body {
 
 /* Swiper Scrollbar Custom Styles */
 .insight-swiper-scrollbar,
-.trend-swiper-scrollbar {
+.trend-swiper-scrollbar,
+.report-swiper-scrollbar {
     margin-right: 20px;
     position: relative !important;
     height: 2px !important;
     background: var(--color-gray-border) !important;
     border-radius: 2px !important;
-    margin-top: 24px !important;
 }
 
 /* Trend Swiper Pagination - 모바일에서 숨김 */
@@ -251,6 +251,10 @@ body {
     
     .trend-swiper-scrollbar {
         display: none !important;
+        margin-right: 0px !important;
+    }
+    
+    .report-swiper-scrollbar {
         margin-right: 0px !important;
     }
     
@@ -285,7 +289,8 @@ body {
 }
 
 .insight-swiper-scrollbar .swiper-scrollbar-drag,
-.trend-swiper-scrollbar .swiper-scrollbar-drag {
+.trend-swiper-scrollbar .swiper-scrollbar-drag,
+.report-swiper-scrollbar .swiper-scrollbar-drag {
     background: var(--color-gray-300) !important;
     border-radius: 2px !important;
     height: 100% !important;


### PR DESCRIPTION
## 변경 사항

### 주요 기능
- 연구보고서 카드 컴포넌트 구현
- 연구보고서 카드 리스트 컴포넌트 구현
- ReportContent 섹션 래퍼 컴포넌트 추가

### 구현된 컴포넌트
- `ReportCard` - 개별 연구보고서 카드 컴포넌트
- `ReportCardList` - Swiper를 사용한 카드 리스트 컴포넌트
- `ReportContent` - 연구보고서 섹션 래퍼 컴포넌트

### 데이터
- `reportData.js` - 5개 연구보고서 데이터 추가

### 스타일
- 이미지 비율 2:3 (세로가 더 긴 형태)
- 호버 시 그림자 효과 적용
- report-swiper-scrollbar 스타일 추가
- 네비게이션 버튼 및 스크롤바 구현

### 웹 접근성
- 카드 리스트에 `role="list"`, `aria-label` 추가
- 개별 카드에 `aria-label` 추가
- SwiperSlide에 `role="listitem"` 추가
- 제목(h4)을 스크린 리더 전용으로 추가 (sr-only)

## 스크린샷
|MO|PC|반응형|
|-----|-----|-----|
|<img width="452" height="678" src="https://github.com/user-attachments/assets/24ac5719-c98e-4eda-8ae3-3d6924ddc7d6" />|<img width="1429" height="724" src="https://github.com/user-attachments/assets/292ee70d-ff8e-4e41-be7a-6c6f304c097d" />|![feature:home-reports-section](https://github.com/user-attachments/assets/4ae78761-1dd2-4c19-985f-d95736958a2a)|


